### PR TITLE
Do not auto-bump jellyfish-client-sdk dev dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "github>product-os/jellyfish-renovate-config"
+  ],
+  "ignoreDeps": [
+    "@balena/jellyfish-client-sdk"
   ]
 }


### PR DESCRIPTION
Doing so would cause a circular dependency as jellyfish-client-sdk has a dependency on jellyfish-types!

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>