### PR TITLE
Add optional loop field to the base contract schema

### DIFF
--- a/lib/core/contracts/contract.ts
+++ b/lib/core/contracts/contract.ts
@@ -35,6 +35,10 @@ export interface Contract<
 	 */
 	name?: string | null;
 	/**
+	 * The slug of the loop that the contract belongs to.
+	 */
+	loop?: string | null;
+	/**
 	 * The type of this contract. The type value should include the version.
 	 *
 	 * For example: 'my-type@1.0.0'

--- a/lib/core/contracts/tests/contract.spec.ts
+++ b/lib/core/contracts/tests/contract.spec.ts
@@ -15,6 +15,7 @@ describe('Contract', () => {
 			version: '1.0.0',
 			type: 'my-type',
 			tags: [],
+			loop: 'l/product-os',
 			markers: [],
 			active: true,
 			created_at: '2019-06-19T08:32:33.142Z',


### PR DESCRIPTION
The loop field can be set to the slug of a loop that the contract belongs to.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>