### PR TITLE
QueryOptions.sortBy can be a string array

### DIFF
--- a/lib/core/backend.ts
+++ b/lib/core/backend.ts
@@ -24,7 +24,7 @@ export interface LinksMap {
 export interface QueryOptions {
 	limit?: number;
 	skip?: number;
-	sortBy?: string;
+	sortBy?: string | string[];
 	sortDir?: 'asc' | 'desc';
 	profile?: boolean;
 	links?: LinksMap;


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>