### PR TITLE
Add versioned_slug field to Contract interface

### DIFF
--- a/lib/core/contracts/contract.ts
+++ b/lib/core/contracts/contract.ts
@@ -31,6 +31,10 @@ export interface Contract<
 	 */
 	slug: string;
 	/**
+	 * A generated field in the format slug @ version
+	 */
+	versioned_slug?: string;
+	/**
 	 * An optional user-friendly name for this contract.
 	 */
 	name?: string | null;
@@ -108,6 +112,7 @@ export interface ContractDefinition<TData = ContractData>
 	extends Omit<
 			OptionalContract<TData>,
 			| 'slug'
+			| 'versioned_slug'
 			| 'type'
 			| 'links'
 			| 'created_at'


### PR DESCRIPTION
Optional for now - until we actually add it as a generated field.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to: https://github.com/product-os/jellyfish-core/pull/860