### PR TITLE
Add correct typing for Worker context and Action function call sig.

### DIFF
--- a/lib/worker/errors.ts
+++ b/lib/worker/errors.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import { JellyfishError } from '../error';
+
+export interface WorkerErrors {
+	WorkerNoExecuteEvent: JellyfishError;
+	WorkerNoElement: JellyfishError;
+	WorkerInvalidVersion: JellyfishError;
+	WorkerInvalidAction: JellyfishError;
+	WorkerInvalidActionRequest: JellyfishError;
+	WorkerInvalidTrigger: JellyfishError;
+	WorkerInvalidTemplate: JellyfishError;
+	WorkerInvalidDuration: JellyfishError;
+	WorkerSchemaMismatch: JellyfishError;
+	WorkerAuthenticationError: JellyfishError;
+}

--- a/lib/worker/index.ts
+++ b/lib/worker/index.ts
@@ -5,3 +5,87 @@
  */
 
 export * from './contracts';
+import { Operation } from 'fast-json-patch';
+import { core, JSONSchema } from '../';
+import { WorkerErrors } from './errors';
+
+export interface WorkerContext {
+	errors: WorkerErrors;
+	defaults: core.JellyfishKernel['defaults'];
+	sync: any;
+	getEventSlug: (type: string) => Promise<string>;
+	getCardById: (lsession: string, id: string) => Promise<core.Contract | null>;
+	getCardBySlug: (
+		lsession: string,
+		slug: string,
+	) => Promise<core.Contract | null>;
+	query: <T extends core.Contract = core.Contract>(
+		lsession: string,
+		schema: Parameters<core.JellyfishKernel['query']>[2],
+		options: Parameters<core.JellyfishKernel['query']>[3],
+	) => Promise<T[]>;
+	privilegedSession: string;
+	insertCard: (
+		lsession: string,
+		typeCard: core.TypeContract,
+		options: {
+			timestamp: any;
+			reason: any;
+			actor: any;
+			originator?: any;
+			attachEvents: any;
+		},
+		card: Partial<core.Contract>,
+	) => Promise<core.Contract | null>;
+	replaceCard: (
+		lsession: string,
+		typeCard: core.TypeContract,
+		options: {
+			timestamp: any;
+			reason: any;
+			actor: any;
+			originator?: any;
+			attachEvents: any;
+		},
+		card: Partial<core.Contract>,
+	) => Promise<core.Contract | null>;
+	patchCard: (
+		lsession: string,
+		typeCard: core.TypeContract,
+		options: {
+			timestamp: any;
+			reason: any;
+			actor: any;
+			originator?: any;
+			attachEvents: any;
+		},
+		card: Partial<core.Contract>,
+		patch: Operation[],
+	) => Promise<core.Contract | null>;
+	cards: {
+		[slug: string]: core.ContractDefinition<core.ContractData>;
+	};
+}
+
+export interface Action {
+	handler: (
+		session: string,
+		context: WorkerContext,
+		// The full contract of the action target.
+		// This is the same contract referenced by the request.card parameter.
+		contract: core.Contract<core.ContractData>,
+		request: {
+			// The full contract of the action being executed.
+			action: core.ActionContract;
+			// The ID or Slug of the action target
+			card: string;
+			actor: string;
+			context: core.Context;
+			timestamp: any;
+			epoch: any;
+			arguments: { [arg: string]: JSONSchema };
+			originator?: string;
+		},
+	) => any;
+	pre: (session: string, context: any, request: any) => any;
+}


### PR DESCRIPTION
The worker contet object is the primary interface for action functions
and its important that is kept consistent and available in a common
place. The follow up to this will be to make the Worker always implement
this interface when generating a context object.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>