### PR TITLE
fix worker context types

### DIFF
--- a/lib/worker/index.ts
+++ b/lib/worker/index.ts
@@ -31,8 +31,8 @@ export interface WorkerContext {
 		options: {
 			timestamp?: string | number | Date;
 			reason?: string;
-			actor?: any;
-			originator?: any;
+			actor?: string;
+			originator?: string;
 			attachEvents?: boolean;
 		},
 		card: Partial<core.Contract>,
@@ -43,8 +43,8 @@ export interface WorkerContext {
 		options: {
 			timestamp?: string | number | Date;
 			reason?: string;
-			actor?: any;
-			originator?: any;
+			actor?: string;
+			originator?: string;
 			attachEvents?: boolean;
 		},
 		card: Partial<core.Contract>,
@@ -55,8 +55,8 @@ export interface WorkerContext {
 		options: {
 			timestamp?: string | number | Date;
 			reason?: string;
-			actor?: any;
-			originator?: any;
+			actor?: string;
+			originator?: string;
 			attachEvents?: boolean;
 		},
 		card: Partial<core.Contract>,


### PR DESCRIPTION
all options are optional and we can be more explicit about the types