### PR TITLE
Allow eval for triggered action request action name

### DIFF
--- a/lib/worker/contracts/triggered-action.ts
+++ b/lib/worker/contracts/triggered-action.ts
@@ -20,7 +20,11 @@ export type TriggeredActionData2 = {
 export interface TriggeredActionData1 {
 	mode?: 'insert' | 'update';
 	type?: string;
-	action?: string;
+	action?:
+		| string
+		| {
+				$eval: string;
+		  };
 	filter?: {
 		[k: string]: unknown;
 	};


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Allow `{ $eval: string }` for action names. Hoping to use this with scheduled actions.