### PR TITLE
Remove the `Context` type

### DIFF
--- a/lib/core/context.ts
+++ b/lib/core/context.ts
@@ -1,4 +1,0 @@
-export interface Context {
-	id: string;
-	[key: string]: any;
-}

--- a/lib/core/index.ts
+++ b/lib/core/index.ts
@@ -1,6 +1,5 @@
 export * from './backend';
 export * from './cache';
-export * from './context';
 export * from './contracts';
 export * from './errors';
 export * from './kernel';


### PR DESCRIPTION
Use the `LogContext` type from `jellyfish-logger` instead.

Change-type: major
Signed-off-by: Carol Schulze <carol@balena.io>