### PR TITLE
Rename `JSONSchema` to `JsonSchema` and match it with the core's dialect

### DIFF
--- a/lib/core/backend.ts
+++ b/lib/core/backend.ts
@@ -4,7 +4,7 @@ import { Cache } from './cache';
 import { CoreErrors } from './errors';
 import { Context } from './context';
 import { Contract, ContractDefinition } from './contracts';
-import { JSONSchema } from '../json-schema';
+import { JsonSchema } from '../json-schema';
 
 export interface StreamChange {
 	id: string;
@@ -65,10 +65,10 @@ export interface StreamPayload {
 export interface Stream extends NodeJS.EventEmitter {
 	query: <TContract extends Contract>(
 		select: QuerySelect,
-		schema: JSONSchema,
+		schema: JsonSchema,
 		options: any,
 	) => Promise<TContract[]>;
-	setSchema: (select: QuerySelect, schema: JSONSchema, options: any) => void;
+	setSchema: (select: QuerySelect, schema: JsonSchema, options: any) => void;
 	push: (payload: StreamPayload) => Promise<void>;
 	tryEmitEvent: (payload: StreamPayload) => Promise<boolean>;
 	close: () => void;
@@ -116,20 +116,20 @@ export interface Backend {
 	query: <TContract extends Contract>(
 		context: Context,
 		select: QuerySelect,
-		schema: JSONSchema,
+		schema: JsonSchema,
 		options: QueryOptions,
 	) => Promise<TContract[]>;
 	prepareQueryForStream: <TContract extends Contract>(
 		context: string,
 		name: string,
 		select: QuerySelect,
-		schema: JSONSchema,
+		schema: JsonSchema,
 		options: QueryOptions,
 	) => StreamQuery<TContract>;
 	stream: (
 		context: Context,
 		select: QuerySelect,
-		schema: JSONSchema,
+		schema: JsonSchema,
 		options: QueryOptions,
 	) => Promise<Stream>;
 	getStatus: () => Promise<BackendStatus>;

--- a/lib/core/contracts/type.ts
+++ b/lib/core/contracts/type.ts
@@ -1,8 +1,8 @@
-import { JSONSchema } from '../../json-schema';
+import { JsonSchema } from '../../json-schema';
 import { Contract, ContractDefinition } from './contract';
 
 export interface TypeData {
-	schema: JSONSchema;
+	schema: JsonSchema;
 	uiSchema?: unknown;
 	[k: string]: unknown;
 }

--- a/lib/core/contracts/view.ts
+++ b/lib/core/contracts/view.ts
@@ -7,27 +7,27 @@
 // tslint:disable: array-type
 
 import { Contract, ContractDefinition } from './contract';
-import { JSONSchema } from '../../json-schema';
+import { JsonSchema } from '../../json-schema';
 
 export interface ViewData {
 	actor?: string;
 	allOf?: {
 		name: string;
-		schema: JSONSchema;
+		schema: JsonSchema;
 	}[];
 	anyOf?: {
 		name: string;
-		schema: JSONSchema;
+		schema: JsonSchema;
 	}[];
 	oneOf?: {
 		name: string;
-		schema: JSONSchema;
+		schema: JsonSchema;
 	}[];
 	/**
 	 * A list of data types this view can return
 	 */
 	types?: string[];
-	schema?: JSONSchema;
+	schema?: JsonSchema;
 	namespace?: string;
 	[k: string]: unknown;
 }

--- a/lib/core/kernel.ts
+++ b/lib/core/kernel.ts
@@ -1,5 +1,5 @@
 import { Operation } from 'fast-json-patch';
-import { JSONSchema } from '../json-schema';
+import { JsonSchema } from '../json-schema';
 import { Backend, BackendStatus, QueryOptions, Stream } from './backend';
 import {
 	ContractMap,
@@ -54,13 +54,13 @@ export interface JellyfishKernel {
 	query: <TContract extends Contract>(
 		context: Context,
 		session: string,
-		schema: JSONSchema,
+		schema: JsonSchema,
 		options?: QueryOptions,
 	) => Promise<TContract[]>;
 	stream: (
 		context: Context,
 		session: string,
-		schema: JSONSchema,
+		schema: JsonSchema,
 	) => Promise<Stream>;
 	defaults: <TContract extends Contract>(
 		contract: Partial<TContract>,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,5 +2,4 @@ export * as core from './core';
 export { JellyfishError } from './error';
 export * as queue from './queue';
 export * as worker from './worker';
-export { JSONSchema } from './json-schema';
 export * from './json-schema';

--- a/lib/json-schema.ts
+++ b/lib/json-schema.ts
@@ -1,115 +1,122 @@
-import type {
-	JSONSchema7Version,
-	JSONSchema7TypeName,
-	JSONSchema7Type,
-} from 'json-schema';
+import { JSONSchema7Type, JSONSchema7TypeName } from 'json-schema';
 
-type JellyfishJSONSchema7Definition = (JSONSchema | boolean) & {
-	$$formula?: string;
-};
+export { JSONSchema7Type, JSONSchema7TypeName };
 
-export interface JSONSchema {
-	$$formula?: string;
-	$$links?: {
-		[key: string]: JSONSchema;
-	};
-	fullTextSearch?: boolean;
-	$id?: string;
-	$ref?: string;
-	$schema?: JSONSchema7Version;
-	$comment?: string;
+export type JsonSchema =
+	| boolean
+	| {
+			// Extensions
+			$$formula?: string;
+			$$links?: {
+				[key: string]: JsonSchema;
+			};
+			formatMaximum?: string;
+			formatMinimum?: string;
+			fullTextSearch?: boolean;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.1
-	 */
-	type?: JSONSchema7TypeName | JSONSchema7TypeName[];
-	enum?: JSONSchema7Type[];
-	const?: JSONSchema7Type;
+			// These are not supported currently
+			// $id?: string;
+			// $ref?: string;
+			// $schema?: JSONSchema7Version;
+			// $comment?: string;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.2
-	 */
-	multipleOf?: number;
-	maximum?: number;
-	exclusiveMaximum?: number;
-	minimum?: number;
-	exclusiveMinimum?: number;
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.1
+			 */
+			type?: JSONSchema7TypeName | JSONSchema7TypeName[];
+			enum?: JSONSchema7Type[];
+			const?: JSONSchema7Type;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.3
-	 */
-	maxLength?: number;
-	minLength?: number;
-	pattern?: string;
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.2
+			 */
+			multipleOf?: number;
+			maximum?: number;
+			exclusiveMaximum?: number;
+			minimum?: number;
+			exclusiveMinimum?: number;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.4
-	 */
-	items?: JellyfishJSONSchema7Definition | JellyfishJSONSchema7Definition[];
-	additionalItems?: JellyfishJSONSchema7Definition;
-	maxItems?: number;
-	minItems?: number;
-	uniqueItems?: boolean;
-	contains?: JSONSchema;
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.3
+			 */
+			maxLength?: number;
+			minLength?: number;
+			pattern?: string;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.5
-	 */
-	maxProperties?: number;
-	minProperties?: number;
-	required?: string[];
-	properties?: {
-		[key: string]: JellyfishJSONSchema7Definition;
-	};
-	patternProperties?: {
-		[key: string]: JellyfishJSONSchema7Definition;
-	};
-	additionalProperties?: JellyfishJSONSchema7Definition;
-	dependencies?: {
-		[key: string]: JellyfishJSONSchema7Definition | string[];
-	};
-	propertyNames?: JellyfishJSONSchema7Definition;
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.4
+			 */
+			items?: JsonSchema | JsonSchema[];
+			maxItems?: number;
+			minItems?: number;
+			contains?: JsonSchema;
+			// These are not supported currently
+			// additionalItems?: JsonSchema;
+			// uniqueItems?: boolean;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.6
-	 */
-	if?: JellyfishJSONSchema7Definition;
-	then?: JellyfishJSONSchema7Definition;
-	else?: JellyfishJSONSchema7Definition;
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.5
+			 */
+			maxProperties?: number;
+			minProperties?: number;
+			required?: string[];
+			properties?: {
+				[key: string]: JsonSchema;
+			};
+			additionalProperties?: JsonSchema;
+			// These are not supported currently
+			/*patternProperties?: {
+		[key: string]: JsonSchema;
+	};*/
+			/*dependencies?: {
+		[key: string]: JSONSchema | string[];
+	};*/
+			// propertyNames?: JsonSchema;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.7
-	 */
-	allOf?: JellyfishJSONSchema7Definition[];
-	anyOf?: JellyfishJSONSchema7Definition[];
-	oneOf?: JellyfishJSONSchema7Definition[];
-	not?: JellyfishJSONSchema7Definition;
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.6
+			 */
+			// These are not supported currently
+			// if?: JsonSchema;
+			// then?: JsonSchema;
+			// else?: JsonSchema;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7
-	 */
-	format?: string;
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.7
+			 */
+			allOf?: JsonSchema[];
+			anyOf?: JsonSchema[];
+			oneOf?: JsonSchema[];
+			not?: JsonSchema;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-8
-	 */
-	contentMediaType?: string;
-	contentEncoding?: string;
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7
+			 */
+			format?: string;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9
-	 */
-	definitions?: {
-		[key: string]: JellyfishJSONSchema7Definition;
-	};
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-8
+			 */
+			// These are not supported currently
+			// contentMediaType?: string;
+			// contentEncoding?: string;
 
-	/**
-	 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-10
-	 */
-	title?: string;
-	description?: string;
-	default?: JSONSchema7Type;
-	readOnly?: boolean;
-	writeOnly?: boolean;
-	examples?: JSONSchema7Type;
-}
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9
+			 */
+			// This is not supported currently
+			/*definitions?: {
+		[key: string]: JsonSchema;
+	};*/
+
+			/**
+			 * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-10
+			 */
+			title?: string;
+			description?: string;
+			examples?: JSONSchema7Type;
+			// These are not supported currently
+			// default?: JSONSchema7Type;
+			// readOnly?: boolean;
+			// writeOnly?: boolean;
+	  };


### PR DESCRIPTION
This commit removes keys that are not recognized and add a couple of missing extensions. It also fixes the definition to accept bools as valid schemas.

Some types from `json-schema` are also reexported.

Change-type: major
Signed-off-by: Carol Schulze <carol@balena.io>