### PR TITLE
Require id in action-request context

### DIFF
--- a/lib/core/contracts/action-request.ts
+++ b/lib/core/contracts/action-request.ts
@@ -17,6 +17,7 @@ export interface ActionRequestData {
 	};
 	action: string;
 	context: {
+		id: string;
 		[k: string]: unknown;
 	};
 	arguments: {

--- a/lib/core/contracts/tests/contract.spec.ts
+++ b/lib/core/contracts/tests/contract.spec.ts
@@ -17,7 +17,9 @@ describe('Contract', () => {
 				action: 'action',
 				actor: 'actor',
 				arguments: {},
-				context: {},
+				context: {
+					id: 'foobar',
+				},
 				epoch: 1,
 				input: {
 					id: 'id2',


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

Require `id` in `action-request.context` objects to make it compatible with the `LogContext` type.

Depends on:
- https://github.com/product-os/jellyfish-core/pull/1166